### PR TITLE
0002-RemoveOPTIMBondEmissions

### DIFF
--- a/0002-RemoveBondEmissions/0002-RemoveBondEmissions.md
+++ b/0002-RemoveBondEmissions/0002-RemoveBondEmissions.md
@@ -1,0 +1,26 @@
+# Context
+
+Since launch, Optim’s Liquidity Bonds have provided the best passive ‘real yield’ on ADA in the Cardano DeFi ecosystem. No possible liquidations, managing positions, pairing ADA with other tokens for an LP, or selling farmed governance tokens are required to achieve superior yield.
+
+While 5.5% was the norm for initial ‘SPO Bonds’, the market clearing rate is now 6.5%+ for ‘ISPO Bonds’ and the system sees few liquidity constraints for borrowers.
+
+
+OPTIM rewards, in the form of a future airdrop, have been in place as an additional incentive for liquidity providers during the first year of protocol operation. We felt it was important to get tokens into the hands of users for a number of reasons: from empowering via governance those with first-hand experience using the protocol to rewarding early-adopters who locked ADA into smart contracts that hadn’t been time-tested.
+
+
+Liquidity Bonds have now been live for nearly an entire year. The community and token distribution has grown, yields on bonds have increased, liquidity constraints have decreased, and the protocol is widely known and respected across the Cardano ecosystem.  
+
+
+Given everything mentioned above, we believe the time is right to revisit OPTIM token emissions for Liquidity Bonds.
+
+# Proposal
+
+
+End all OPTIM token emissions for Liquidity Bond buyers.
+
+
+The only exception is for SPOs that certify SPO Bonds with the Optim team.
+
+The end of OPTIM emissions will be effective immediately on all bonds issued after the proposal passes.
+
+

--- a/0002-RemoveBondEmissions/0002-RemoveBondEmissions.md
+++ b/0002-RemoveBondEmissions/0002-RemoveBondEmissions.md
@@ -1,4 +1,9 @@
-# Context
+# 0000-ProposalTemplate
+
+- Status: Proposed
+- Authors: Optim Labs
+
+## Context
 
 Since launch, Optim’s Liquidity Bonds have provided the best passive ‘real yield’ on ADA in the Cardano DeFi ecosystem. No possible liquidations, managing positions, pairing ADA with other tokens for an LP, or selling farmed governance tokens are required to achieve superior yield.
 
@@ -13,7 +18,7 @@ Liquidity Bonds have now been live for nearly an entire year. The community and 
 
 Given everything mentioned above, we believe the time is right to revisit OPTIM token emissions for Liquidity Bonds.
 
-# Proposal
+## Proposal
 
 
 End all OPTIM token emissions for Liquidity Bond buyers.

--- a/0002-RemoveBondEmissions/0002-RemoveOPTIMBondEmissions.md
+++ b/0002-RemoveBondEmissions/0002-RemoveOPTIMBondEmissions.md
@@ -1,6 +1,6 @@
 # 0001 - RemoveOPTIMBondEmissions
 
-- Status: Judged
+- Status: Accepted
 - Authors: Optim Labs
 
 ## Context

--- a/0002-RemoveBondEmissions/0002-RemoveOPTIMBondEmissions.md
+++ b/0002-RemoveBondEmissions/0002-RemoveOPTIMBondEmissions.md
@@ -1,6 +1,6 @@
 # 0001 - RemoveOPTIMBondEmissions
 
-- Status: Proposed
+- Status: Judged
 - Authors: Optim Labs
 
 ## Context

--- a/0002-RemoveBondEmissions/0002-RemoveOPTIMBondEmissions.md
+++ b/0002-RemoveBondEmissions/0002-RemoveOPTIMBondEmissions.md
@@ -1,4 +1,4 @@
-# 0000-ProposalTemplate
+# 0001 - RemoveOPTIMBondEmissions
 
 - Status: Proposed
 - Authors: Optim Labs
@@ -9,20 +9,15 @@ Since launch, Optim’s Liquidity Bonds have provided the best passive ‘real y
 
 While 5.5% was the norm for initial ‘SPO Bonds’, the market clearing rate is now 6.5%+ for ‘ISPO Bonds’ and the system sees few liquidity constraints for borrowers.
 
-
 OPTIM rewards, in the form of a future airdrop, have been in place as an additional incentive for liquidity providers during the first year of protocol operation. We felt it was important to get tokens into the hands of users for a number of reasons: from empowering via governance those with first-hand experience using the protocol to rewarding early-adopters who locked ADA into smart contracts that hadn’t been time-tested.
 
-
 Liquidity Bonds have now been live for nearly an entire year. The community and token distribution has grown, yields on bonds have increased, liquidity constraints have decreased, and the protocol is widely known and respected across the Cardano ecosystem.  
-
 
 Given everything mentioned above, we believe the time is right to revisit OPTIM token emissions for Liquidity Bonds.
 
 ## Proposal
 
-
 End all OPTIM token emissions for Liquidity Bond buyers.
-
 
 The only exception is for SPOs that certify SPO Bonds with the Optim team.
 


### PR DESCRIPTION
Tldr; despite being small, if TVL skyrockets due to natural demand on the product, the DAO will unnecessarily bleed emissions.

[Rendered](https://github.com/OptimFinance/odao-proposals/blob/proposal0002/0002-RemoveBondEmissions/0002-RemoveOPTIMBondEmissions.md)