### PR TITLE
0007 - SplashAdjustment 

### DIFF
--- a/0007-SplashAdjustment/0007-SplashAdjustment.md
+++ b/0007-SplashAdjustment/0007-SplashAdjustment.md
@@ -1,0 +1,20 @@
+# 0007-SplashAdjustment
+
+- Status: Proposed
+- Authors: Optim Labs
+
+## Context
+
+After the proposal 0006 was put up for a vote we were notified by the Splash team that the terms of their token launch have been adjusted. As such we require a new proposal to push forward in alignment with the new terms as well as our consensus on what's the best positioning around the event.
+
+Most notably, the public price has been increased from 0.175 per token to 0.250. Thusly we propose here an authorization of a large chunk of ADA from the treasury to be put under ODAO Council management to appropriately handle this event in a dynamic and flexible way. 
+
+The rest of the prior proposal is reaffirmed, and costs are the same, with additional ADA to cover for the higher cost of LP'ing the 2.5% from the voting bootstrap (~47k ADA) being covered by the Splash DAO.
+
+## Proposal
+
+### Splash Public Event Positioning
+
+The cost of acquiring and LP'ing 1% is 250k + 62.5k = 312.5k. Assuming we can provide liquidity at the sale price, which is not a given. Furthermore we must authorize a larger quantity of ADA for the event in order to avoid being pro-rata'd.
+
+Thus, authorization of an additional 1M ADA is required for this purpose. ADA not used and Splash acquired is under ODAO Council management for the purposes of agile execution and positining of liquidity.

--- a/0007-SplashAdjustment/0007-SplashAdjustment.md
+++ b/0007-SplashAdjustment/0007-SplashAdjustment.md
@@ -1,6 +1,6 @@
 # 0007-SplashAdjustment
 
-- Status: Proposed
+- Status: Accepted
 - Authors: Optim Labs
 
 ## Context

--- a/0007-SplashAdjustment/0007-SplashAdjustment.md
+++ b/0007-SplashAdjustment/0007-SplashAdjustment.md
@@ -13,6 +13,10 @@ The rest of the prior proposal is reaffirmed, and costs are the same, with addit
 
 ## Proposal
 
+### Splash VE Bootstrap Event Positioning
+
+The 0006 decision remains the same, but with the initial price being higher, we explicitly mention that that higher cost is not taken on by the ODAO. Vote Bootstrapping pricings and the other terms remain the same otherwise.
+
 ### Splash Public Event Positioning
 
 The cost of acquiring and LP'ing 1% is 250k + 62.5k = 312.5k. Assuming we can provide liquidity at the sale price, which is not a given. Furthermore we must authorize a larger quantity of ADA for the event in order to avoid being pro-rata'd.


### PR DESCRIPTION
This is a very quick adjustment to 0006 as the Splash launch plans have changed during our vote

The ODAO participation is already in stone, just need to make explicit the public event positioning 