### PR TITLE
0008 -- SplashAdjustment2

### DIFF
--- a/0008-SplashAdjustment2/0008-SplashAdjustment2.md
+++ b/0008-SplashAdjustment2/0008-SplashAdjustment2.md
@@ -1,0 +1,24 @@
+# 0008-SplashAdjustment2
+
+- Status: Proposed
+- Authors: Optim Labs
+
+## Context
+
+After reviewing the (partial) source code of Splash we no longer believe that there has been a sufficient approval for pro rata protection in order to acquire 1% of Splash in the public launch. 
+
+We also approve here the VE lockup of the 80/20 ODAO holdings to proceed via a yet unannounced smart contract system, and grant management over it fully to the ODAO Council.
+
+## Proposal
+
+### Increase Splast Pro-Rata Authorized Size
+
+We approve an additional 1M ADA purely for pro-rata protection such that we may acquire our desired 1% SPLASH. 
+
+The ADA returns to the general ODAO Treasury afterwards. 
+
+### VE Lockup Method
+
+As part of the terms of the VE Bootstrap deal, the ODAO is required to lockup the 2.5% for the maximum duration. It is at ODAO Council's discretion to manage the rest of the SPLASH ownership, with a present intent to fully max-lock it. 
+
+Instead of going with the direct lockup method, we authorize the use of derivative contracts to achieve the desired result. 

--- a/0008-SplashAdjustment2/0008-SplashAdjustment2.md
+++ b/0008-SplashAdjustment2/0008-SplashAdjustment2.md
@@ -1,6 +1,6 @@
 # 0008-SplashAdjustment2
 
-- Status: Proposed
+- Status: Accepted
 - Authors: Optim Labs
 
 ## Context


### PR DESCRIPTION
After reviewing the (partial) source code of Splash we no longer believe that there has been a sufficient approval for pro rata protection in order to acquire 1% of Splash in the public launch. 

We also approve here the VE lockup of the 80/20 ODAO holdings to proceed via a yet unannounced smart contract system, and grant management over it fully to the ODAO Council.

[RENDERED](https://github.com/OptimFinance/odao-proposals/blob/proposal0008/0008-SplashAdjustment2/0008-SplashAdjustment2.md)
