### PR TITLE
0009 -- Bug Bounty Program

### DIFF
--- a/0009-BugBountyProgram/0009-BugBountyProgram.md
+++ b/0009-BugBountyProgram/0009-BugBountyProgram.md
@@ -1,4 +1,4 @@
-# 0008-BugBountyProgram
+# 0009-BugBountyProgram
 
 - Status: Proposed
 - Authors: Optim Labs

--- a/0009-BugBountyProgram/0009-BugBountyProgram.md
+++ b/0009-BugBountyProgram/0009-BugBountyProgram.md
@@ -1,0 +1,26 @@
+# 0008-BugBountyProgram
+
+- Status: Proposed
+- Authors: Optim Labs
+
+## Context
+
+In preparation for both the launch of Splash and OADA, which relies heavily on the former -- we propose a bug bounty for the open sourcing of a total of 90k ADA from the ODAO Treasury to be used to run a program aimed at both giving confidence in the products, as well as ensuring the safety of our deployed capital. 
+
+For the portion of the funds allocated to securing the Splash Pools, the majority of payouts (if any) will be taken care by the Splash team. Specifically, it will be a 70:30 split between the two parties.
+
+## Proposal
+
+### Bug Bounty Program
+
+Authorize the use of 90k ADA from the ODAO Treasury to Optim Labs to run an Open Source Bug Bounty Program concerning:
+
+- OTOKEN Framework (OADA Core): 50k ADA
+- Splash Stableswap: 20k ADA
+- Splash Weighted Pool: 20k ADA
+
+It is to be run at Optim Labs' discretion, including setting the appropriate judgement of submissions and payout scheme.
+
+Authorized indefinitely, until Optim Labs decides to deprecate the Program. 
+
+The funds, while idle, may be used for staking and liquidity provision in the OADA and Splash systems (sOADA, OADA/ADA LP) with the approval of the ODAO Council.

--- a/0009-BugBountyProgram/0009-BugBountyProgram.md
+++ b/0009-BugBountyProgram/0009-BugBountyProgram.md
@@ -1,6 +1,6 @@
 # 0009-BugBountyProgram
 
-- Status: Judged
+- Status: Accepted
 - Authors: Optim Labs
 
 ## Context

--- a/0009-BugBountyProgram/0009-BugBountyProgram.md
+++ b/0009-BugBountyProgram/0009-BugBountyProgram.md
@@ -1,6 +1,6 @@
 # 0009-BugBountyProgram
 
-- Status: Proposed
+- Status: Judged
 - Authors: Optim Labs
 
 ## Context


### PR DESCRIPTION
In preparation for both the launch of Splash and OADA, which relies heavily on the former -- we propose a bug bounty for the open sourcing of a total of 90k ADA from the ODAO Treasury to be used to run a program aimed at both giving confidence in the products, as well as ensuring the safety of our deployed capital. 

For the portion of the funds allocated to securing the Splash Pools, the majority of payouts (if any) will be taken care by the Splash team. Specifically, it will be a 70:30 split between the two parties.

[FULL RENDERED](https://github.com/OptimFinance/odao-proposals/blob/proposal0009/0009-BugBountyProgram/0009-BugBountyProgram.md)