### PR TITLE
0012 -- ICC Vote

### DIFF
--- a/0012-ICCVote/0012-ICCVote.md
+++ b/0012-ICCVote/0012-ICCVote.md
@@ -1,0 +1,21 @@
+# 0012-ICCVote
+
+- Status: Judged
+- Authors: Optim Labs
+
+## Context
+
+The ODAO has control over 2.5M ADA in stake, and it is a good idea to make use of it in the ICC elections. 
+
+With public submissions and discussion in the odao-public discord channel by the ODAO participants we have gathered the following ranking, and if accepted, will be voted on. 
+
+## Proposal
+
+Vote on the following ICC candidacies, with the follwoing rankings:
+
+1. Cardano Japan
+2. The Cardano Atlantic Council
+3. Mauro Agustín Andreoli
+4. Joshua Stone
+5. Lloyd Duhon
+6. Andrew DonovanProposed


### PR DESCRIPTION
## Context

The ODAO has control over 2.5M ADA in stake, and it is a good idea to make use of it in the ICC elections. 

With public submissions and discussion in the odao-public discord channel by the ODAO participants we have gathered the following ranking, and if accepted, will be voted on. 

## Proposal

Vote on the following ICC candidacies, with the follwoing rankings:

1. Cardano Japan
2. The Cardano Atlantic Council
3. Mauro Agustín Andreoli
4. Joshua Stone
5. Lloyd Duhon
6. Andrew DonovanProposed

[RENDERED](https://github.com/OptimFinance/odao-proposals/blob/proposal0012/0012-ICCVote/0012-ICCVote.md)