### PR TITLE
0015 -- OPTIMiz Conversion

### DIFF
--- a/0015-OPTIMizConversion/0015-OPTIMizConversion.md
+++ b/0015-OPTIMizConversion/0015-OPTIMizConversion.md
@@ -1,6 +1,6 @@
 # 0015-OPTIMizConversion
 
-- Status: Proposed
+- Status: Judged
 - Authors: Optim Labs
 
 ## Context

--- a/0015-OPTIMizConversion/0015-OPTIMizConversion.md
+++ b/0015-OPTIMizConversion/0015-OPTIMizConversion.md
@@ -1,6 +1,6 @@
 # 0015-OPTIMizConversion
 
-- Status: Judged
+- Status: Accepted
 - Authors: Optim Labs
 
 ## Context

--- a/0015-OPTIMizConversion/0015-OPTIMizConversion.md
+++ b/0015-OPTIMizConversion/0015-OPTIMizConversion.md
@@ -1,0 +1,42 @@
+# 0015-OPTIMizConversion
+
+- Status: Proposed
+- Authors: Optim Labs
+
+## Context
+
+This proposal seeks to define in full ALL present and future ways that will be available to instantiate the conversion process from OPTIMiz to OPTIM.
+
+OPTIMiz Tokens issued in 0001 as part of the ILE event have lacked a conversion method into OPTIM, and while 0011 defined a single way of doing so, after long discussions with the ODAO Members we have come to a conclusion that in order to achieve meaningful participation the numbers have to be made slightly more attractive. 
+
+We propose to define adjusted OADA-locking OPTIMiz conversions, as well as define *ALL* future conversion methods so that users may take the decision in full knowing their options and not betting on more arriving later. 
+
+Mainly, there are two routes
+1) veOPTIM80/20 Staking 
+2) OADA Lockup 
+
+Detailed in the proposal
+
+## Proposal
+
+### OPTIMiz conversions
+
+Here we outline *all* of the future ways to convert OPTIMiz, with no others added. 
+
+#### veOPTIM80/20 Staking
+
+The conversion method relies upon the veOPTIM80/20 staking to be active. Notably, it requires the veOPTIM80/20 LP to be locked for the maximum duration. 
+We allow, the lock of a further 1 year on top of that, to convert an OPTIMiz position upwards of maximally equal that of the OPTIM in LP owned, which while it shifts over time, it only matters for the initial creation of a conversion lock.
+
+The conversion lock may not be unlocked early. 
+
+#### OADA Lockup
+
+There are three ways to convert OPTIMiz to OPTIM under this category, all of which replace the method defined in 0011, but work in the exact same way.
+Notably, by having the user lockup OADA in proportion to OPTIMiz for a duration, after which all OADA is returned and OPTIMiz is now OPTIM. 
+The users are given an option to unlock the position early, forefitting half of the OPTIM that was 'vested up until that point in time'.
+
+The options are:
+6 months - 7 OADA : 1 OPTIMiz
+9 months - 4.5 OADA : 1 OPTIMiz
+12 months - 3 OADA : 1 OPTIMiz


### PR DESCRIPTION
This proposal seeks to define in full ALL present and future ways that will be available to instantiate the conversion process from OPTIMiz to OPTIM.

OPTIMiz Tokens issued in 0001 as part of the ILE event have lacked a conversion method into OPTIM, and while 0011 defined a single way of doing so, after long discussions with the ODAO Members we have come to a conclusion that in order to achieve meaningful participation the numbers have to be made slightly more attractive. 

We propose to define adjusted OADA-locking OPTIMiz conversions, as well as define *ALL* future conversion methods so that users may take the decision in full knowing their options and not betting on more arriving later. 

Mainly, there are two routes
1) veOPTIM80/20 Staking 
2) OADA Lockup 

Detailed in the proposal

[RENDERED](https://github.com/OptimFinance/odao-proposals/blob/proposal0015/0015-OPTIMizConversion/0015-OPTIMizConversion.md)