### PR TITLE
0018 -- OADA ADA Lending Addition

### DIFF
--- a/0017-OADADexAMOUpdate/0017-OADADexAMOUpdate.md
+++ b/0017-OADADexAMOUpdate/0017-OADADexAMOUpdate.md
@@ -1,0 +1,29 @@
+# 0017-OADADexAMOUpdate
+
+- Status: Proposed
+- Authors: Optim Labs
+
+## Context
+
+In the initial OADA Deployment the DEX AMO has been set up with a deposit guard too restrictive in order to safeguard the reserves from unforeseen circumstances.
+
+Now that we have acquired a significantly expanded confidence in the performance of the strategy as well as confidence in the ability to timely execute the epochly routine. 
+
+To that end we wish to push the deposit guard parameter of the DEX AMO to the limit of its efficiency, as well as update the splash stableswap deployment in preparation for the activation of their DAO.
+
+Furthermore, the proposal makes a migration from the old stableswap pool to the new one, as well as a new Wingriders OADA/ADA stableswap.
+
+## Proposal
+
+### OADA DEX AMO Update
+
+Update the "DEX AMO" (as currently understood, incliuding the strategy, the amo rule, and the auction whitelist) to be derived from the new strategy script of 3ae44baefa4d14f672d1dd9d13445cf93efbc367c08dc392e183edad
+
+This script is parameterized by the new splash stableswap pool, and a new 'guard' parameter that allows deposits into the stable pool in a certain bounded range to prevent system reserve loss (in simple terms, don't sell OADA at under 1 ADA), initially set higher than ideal for added sanity levels of security. 
+
+Furthermore, we change the stablepool for a new deployment to allow the epoch-crossing ADA to be staked, which was previously not happening due to an oversight.
+
+### OADA/ADA Liquidity move
+
+From the ~1.5M ADA TVL (at 1 OADA = 0.999362 ADA), i.e. 657,435.134585 ADA and 843,821.217589 OADA, 
+Move maxium of 400k TVL into Wingriders Stableswap (with ODAO Council having the authority on how much exactly, and authority to move that sum at will between the Splash and Wingriders on) and the remaining sum of ~1.1M ADA TVL, into the new Splash Stablepool

--- a/0017-OADADexAMOUpdate/0017-OADADexAMOUpdate.md
+++ b/0017-OADADexAMOUpdate/0017-OADADexAMOUpdate.md
@@ -1,6 +1,6 @@
 # 0017-OADADexAMOUpdate
 
-- Status: Judged
+- Status: Accepted
 - Authors: Optim Labs
 
 ## Context

--- a/0017-OADADexAMOUpdate/0017-OADADexAMOUpdate.md
+++ b/0017-OADADexAMOUpdate/0017-OADADexAMOUpdate.md
@@ -1,6 +1,6 @@
 # 0017-OADADexAMOUpdate
 
-- Status: Proposed
+- Status: Judged
 - Authors: Optim Labs
 
 ## Context

--- a/0018-OADAADALendingAddition/0018-OADAADALendingAddition.md
+++ b/0018-OADAADALendingAddition/0018-OADAADALendingAddition.md
@@ -1,6 +1,6 @@
 # 0018-OADAADALendingAddition
 
-- Status: Proposed
+- Status: Judged
 - Authors: Optim Labs
 
 ## Context

--- a/0018-OADAADALendingAddition/0018-OADAADALendingAddition.md
+++ b/0018-OADAADALendingAddition/0018-OADAADALendingAddition.md
@@ -1,0 +1,39 @@
+# 0018-OADAADALendingAddition
+
+- Status: Proposed
+- Authors: Optim Labs
+
+## Context
+
+With the initial success of the OADA System we seek furthher avenues for opportunity in the ecosystem to grow the base for its yield. 
+
+As initially outlined, the first step in that direction was adding the avenue to lend out the system reserves in Liqwid, and this proposal adds such capacity. 
+
+Thanks to our proposal in the Liqwid DAO, lending ADA has become more attractive. Thus, with our developement of ADA the Lending Strategy, we propose the structure under which it will operate.
+
+## Proposal
+
+### Addition of the Liqwid ADA Lending Strategy
+
+We whitelist the following script `5416303af5dd8d47818f4c19141d7f122c955ecc1eb1047509be68f1` as the Liqwid ADA Lending Strategy, to be also whitelisted into the Stake Auction Whitelist.
+
+### Operation of OADA System with Liqwid ADA Lending Strategy
+
+The Liqwid ADA Lending Strategy introduces an offchain controller guidance parameter under control of the ODAO Council, namely, the LiqwidADALendingCapacity. It is meant to serve as a maximum amount of ADA allocated to be lent out during the epoch to allow smooth deposits and withdrawals of the reserves to and from the Lending Market. We initialize the parameter to 15M ADA, corresponding to 20% of the total deposits into the Liqwid ADA market.
+
+We augument the operations of the system, to the following:
+
+At the beginning of every epoch, gather reserves. 
+- Use sufficient reserves to buy back OADA to restore price to 0.999. 
+- Find the pot of reserves allocated to the Liqwid ADA Ledning Strategy: 
+    - Set the amount of ADA used to deposit into Liqwid as = min(LiqwidADALendingCapacity, 0.8 * TotalADAReserves)
+- Find the pot of reserves allocated to the DEX AMO:
+    - Set the amount of ADA used to deposit into Splash as 90% of the remaining funds
+    - Use the remaining funds idle for first capital for mid-epoch buybacks 
+
+During the epoch operations: 
+- ADA auctioned off in the stake auction comes first from the ADA Lending Strategy until empty, then from the DEX AMO
+- In case of a need for capital to buy back OADA, the ADA will be moved from the Liqwid deposit into the DEX AMO and used for it
+    - Currently such buybacks only occur when the price drops under 0.99 and bring it back up to 0.99 ADA per OADA
+
+In case of inability to withdraw from Liqwid, the system can do nothing but wait until it is made possible. 


### PR DESCRIPTION
## Context

With the initial success of the OADA System we seek furthher avenues for opportunity in the ecosystem to grow the base for its yield. 

As initially outlined, the first step in that direction was adding the avenue to lend out the system reserves in Liqwid, and this proposal adds such capacity. 

Thanks to our proposal in the Liqwid DAO, lending ADA has become more attractive. Thus, with our developement of ADA the Lending Strategy, we propose the structure under which it will operate.

[RENDERED](https://github.com/OptimFinance/odao-proposals/blob/proposal0018/0018-OADAADALendingAddition/0018-OADAADALendingAddition.md)