### PR TITLE
Proposal 0021 -- Catalyst Vote

### DIFF
--- a/0021-CatalystVote/0021-CatalystVote.md
+++ b/0021-CatalystVote/0021-CatalystVote.md
@@ -1,0 +1,56 @@
+# 0021-CatalystVote
+
+- Status: Proposed
+- Authors: Optim Labs
+
+## Context
+
+Within the power given to the ODAO by 0016, the execution of the proposal was successful, and the results thereof have yielded fruits plenty, including a 20.9M ADA vote capture for the ODAO.
+The results of the Catalyst Partner Program are respected and not subject to this proposal, as they have been pre-approved to be *not questioned* but simply voted on as the winners chose. 
+
+Such a direct and meritocratic split of power has proven desirable, and in our small pilot program proven successful. 
+While this proposal does not *outline* the next Catalyst Partner Program explicitly, for the next one we want to open it up for more votes, and allow more participation by projects looking to contribute.
+This proposal aims to explain the thought process as well as transparently outline the plan for our stewardship of such vote power and set a clear and strong precedent for how the ODAO will vote with the captured ADA.
+
+For any votes not subject to a transparent and freely joinable program that allows projects to earn votes, we set a commit to utilize any free votes to only vote for proposals that directly benefit the Optim project. 
+
+## Proposal
+
+### Highlighting the Catalyst Partner Project Votes
+
+These votes are not subject to being approved, but are mentioned here for full transparency. 
+
+#### Top 1: USDM
+
+Won 2 votes, chose to vote on:
+- Serve remittance use cases through Lirium's institutional API and Mastercard Crypto Credentials
+- Cardano Component UI Library
+
+#### Top 2: SNEK
+
+Won 2 votes, chose to vote on: 
+- Snek.fun v2 : Onboarding Cross-Chain Users to Cardano
+- DexHunter One-Click Swaps
+
+#### Top 3: FluidTokens
+
+Won 1 vote, chose to vote on:
+- FluiDeFi - EVM/BTC wallets with any Cardano DApp
+
+#### Top 4: Clarity
+
+Won 1 vote, chose to vote on:
+- Clarity X Plug and Play: On-Chain Investment Arm for Cardano Ecosystem Investments
+
+#### Top 5: Rosen Bridge
+
+Won 1 votem chose to vote on:
+- Onboarding SUI Ecosystem to Cardano via Rosen Bridge
+
+### ODAO Free Votes
+
+We vote on all 6 proposals by Optim Labs.
+And 1 proposal from DexHunter:
+- DexHunter OADA Mint/Burn routing support
+
+In light of no further proposals being directly of direct line of support to the Optim products, the remaining 3 ODAO votes are not utilized.

--- a/0021-CatalystVote/0021-CatalystVote.md
+++ b/0021-CatalystVote/0021-CatalystVote.md
@@ -50,11 +50,15 @@ Won 1 votem chose to vote on:
 ### ODAO Free Votes
 
 We vote on all 6 proposals by Optim Labs.
+
 1 proposal from DexHunter:
 - DexHunter OADA Mint/Burn routing support
+
 1 proposal from WingRiders: 
 - Open-Source Rapid DEX: Batcher-less, instant, with transaction chaining
+
 1 proposal from Minswap:
 - Minswap Lending Market - Long/Short
+
 1 proposal from Sundae Labs:
 - Sundae Labs: Amaru Node Development Support - Rust Developer Contract

--- a/0021-CatalystVote/0021-CatalystVote.md
+++ b/0021-CatalystVote/0021-CatalystVote.md
@@ -50,7 +50,11 @@ Won 1 votem chose to vote on:
 ### ODAO Free Votes
 
 We vote on all 6 proposals by Optim Labs.
-And 1 proposal from DexHunter:
+1 proposal from DexHunter:
 - DexHunter OADA Mint/Burn routing support
-
-In light of no further proposals being directly of direct line of support to the Optim products, the remaining 3 ODAO votes are not utilized.
+1 proposal from WingRiders: 
+- Open-Source Rapid DEX: Batcher-less, instant, with transaction chaining
+1 proposal from Minswap:
+- Minswap Lending Market - Long/Short
+1 proposal from Sundae Labs:
+- Sundae Labs: Amaru Node Development Support - Rust Developer Contract


### PR DESCRIPTION
Within the power given to the ODAO by 0016, the execution of the proposal was successful, and the results thereof have yielded fruits plenty, including a 20.9M ADA vote capture for the ODAO.
The results of the Catalyst Partner Program are respected and not subject to this proposal, as they have been pre-approved to be *not questioned* but simply voted on as the winners chose. 

Such a direct and meritocratic split of power has proven desirable, and in our small pilot program proven successful. 
While this proposal does not *outline* the next Catalyst Partner Program explicitly, for the next one we want to open it up for more votes, and allow more participation by projects looking to contribute.
This proposal aims to explain the thought process as well as transparently outline the plan for our stewardship of such vote power and set a clear and strong precedent for how the ODAO will vote with the captured ADA.

For any votes not subject to a transparent and freely joinable program that allows projects to earn votes, we set a commit to utilize any free votes to only vote for proposals that directly benefit the Optim project. 

[FULL PROPOSAL](https://github.com/OptimFinance/odao-proposals/blob/proposal0021/0021-CatalystVote/0021-CatalystVote.md)