### PR TITLE
Proposal 0022 -- Splash Vote And Prep

### DIFF
--- a/0022-SplashVoteAndPrep/0022-SplashVoteAndPrep.md
+++ b/0022-SplashVoteAndPrep/0022-SplashVoteAndPrep.md
@@ -1,6 +1,6 @@
 # 0022-SplashVoteAndPrep
 
-- Status: Proposed
+- Status: Accepted
 - Authors: Optim Labs
 
 ## Context

--- a/0022-SplashVoteAndPrep/0022-SplashVoteAndPrep.md
+++ b/0022-SplashVoteAndPrep/0022-SplashVoteAndPrep.md
@@ -1,4 +1,4 @@
-# 0021-CatalystVote
+# 0022-SplashVoteAndPrep
 
 - Status: Proposed
 - Authors: Optim Labs

--- a/0022-SplashVoteAndPrep/0022-SplashVoteAndPrep.md
+++ b/0022-SplashVoteAndPrep/0022-SplashVoteAndPrep.md
@@ -27,3 +27,7 @@ Withdraw all liquidity, and use all of the underlying SPLASH in OSPLASH and comm
 Use remaining owned SPLASH, and SPLASH provided in SPLASH/OADA (withdrawn first) as liquidity for OSPLASH/SPLASH, in a pool managed entirely by the ODAO Council. 
 
 In the future, we may elect to add further max-locked SPLASH from this liquidity, but initially we believe that ~2.7% of the supply is sufficient bootstrapping for it. 
+
+### Temporary Management of Emissions by Optim Labs
+
+We give the authority of the choice of direction of emissions through the OSPLASH system to Optim Labs for the first 6 months of the system's lifetime, reverting to ODAO Council afterwards.

--- a/0022-SplashVoteAndPrep/0022-SplashVoteAndPrep.md
+++ b/0022-SplashVoteAndPrep/0022-SplashVoteAndPrep.md
@@ -1,0 +1,29 @@
+# 0021-CatalystVote
+
+- Status: Proposed
+- Authors: Optim Labs
+
+## Context
+
+The Splash team has published a proposal to, prior to the launch of their VE system, change the governance token from an 80/20 SPLASH/ADA LP token to just the SPLASH token. 
+
+We intend to support the proposal of this change with this vote, and prepare for the launch of their VE system with the launch of our OSPLASH, a liquid locker system that shall be revealed in full in the coming weeks.
+
+## Proposal
+
+### Vote in favor of the change
+
+The Splash vote is hosted here:
+
+https://www.clarity.vote/organizations/SplashTmp/governance/polls/-OGZG0or83xlmKjnYUM5
+
+To vote, with all LP tokens held by the ODAO vote "Change", i.e. support the move to single token VE. 
+
+### Repurpose all SPLASH liquidity
+
+Of SPLASH/ADA LP held, 1,436,022,327,474 (all) is acquired via VBE. 
+Withdraw all liquidity, and use all of the underlying SPLASH in OSPLASH and commit it as unstaked to the system. 
+
+Use remaining owned SPLASH, and SPLASH provided in SPLASH/OADA (withdrawn first) as liquidity for OSPLASH/SPLASH, in a pool managed entirely by the ODAO Council. 
+
+In the future, we may elect to add further max-locked SPLASH from this liquidity, but initially we believe that ~2.7% of the supply is sufficient bootstrapping for it. 


### PR DESCRIPTION
The Splash team has published a proposal to, prior to the launch of their VE system, change the governance token from an 80/20 SPLASH/ADA LP token to just the SPLASH token. 

We intend to support the proposal of this change with this vote, and prepare for the launch of their VE system with the launch of our OSPLASH, a liquid locker system that shall be revealed in full in the coming weeks.

[RENDERED](https://github.com/OptimFinance/odao-proposals/blob/proposal0022/0022-SplashVoteAndPrep/0022-SplashVoteAndPrep.md)