### PR TITLE
Proposal 0023 -- OUSD Prep

### DIFF
--- a/0023-OUSDPrep/0023-OUSDPrep.md
+++ b/0023-OUSDPrep/0023-OUSDPrep.md
@@ -12,6 +12,7 @@ In order to prepare ourselves for the OUSD launch, we must seed the liqudity for
 Withdraw 1M out of 1.1M (OADA + ADA) liquidity from the OADA/ADA stableswap. Swap all ADA into wanUSDC, and keep the OADA for the OADA/OUSD pool. 
 Withdraw the liquidity from the O/ADA pool on Splash and use the ADA to acquire wanUSDC. Provide the liquidity back.
 Withdraw the liquidity from the O/OADA pool on Splash and convert 200k OADA into wanUSDC. Provide it as liquitiy back.
+Withdraw the liquidity from the OADA/ADA pool on Wingriders and convert all of it into wanUSDC. Sideline it into the ODAO Treasury.
 
 Liquidity mangement, fees and dex allocation remain under control of ODAO Council.
 

--- a/0023-OUSDPrep/0023-OUSDPrep.md
+++ b/0023-OUSDPrep/0023-OUSDPrep.md
@@ -11,7 +11,7 @@ In order to prepare ourselves for the OUSD launch, we must seed the liqudity for
 
 Withdraw 1M out of 1.1M (OADA + ADA) liquidity from the OADA/ADA stableswap. Swap all ADA into wanUSDC, and keep the OADA for the OADA/OUSD pool. 
 Withdraw the liquidity from the O/ADA pool on Splash and use the ADA to acquire wanUSDC. Provide the liquidity back.
-Withdraw the liquidity from the O/OADA pool on Splash and convert 200k OADA into wanUSDC. Provide it as liquitiy back.
+Withdraw the liquidity from the O/OADA pool on Splash and convert 500k OADA into wanUSDC. Provide it as liquitiy back.
 Withdraw the liquidity from the OADA/ADA pool on Wingriders and convert all of it into wanUSDC. Sideline it into the ODAO Treasury.
 
 Liquidity mangement, fees and dex allocation remain under control of ODAO Council.

--- a/0023-OUSDPrep/0023-OUSDPrep.md
+++ b/0023-OUSDPrep/0023-OUSDPrep.md
@@ -1,0 +1,26 @@
+# 0023-OUSDPrep
+
+- Status: Proposed
+- Authors: Optim Labs
+
+## Treasury Allocation
+
+In order to prepare ourselves for the OUSD launch, we must seed the liqudity for it. A brave move in interim to have the $O token be the primary source of wanUSDC liquidity on Cardano is proposed.
+
+## Liquidity Adjustments
+
+Withdraw 1M out of 1.1M (OADA + ADA) liquidity from the OADA/ADA stableswap. Swap all ADA into wanUSDC, and keep the OADA for the OADA/OUSD pool. 
+Withdraw the liquidity from the O/ADA pool on Splash and use the ADA to acquire wanUSDC. Provide the liquidity back.
+Withdraw the liquidity from the O/OADA pool on Splash and convert 200k OADA into wanUSDC. Provide it as liquitiy back.
+
+Liquidity mangement, fees and dex allocation remain under control of ODAO Council.
+
+Execution of the swap at best possible rate given a reasonable window of ~7 days after the proposal is accepted is given to Optim Labs.
+
+The intention is to, after the launch of OUSD, is to use the wanUSDC stable as a reserve asset and convert this liquidity into OUSD.
+
+## Treasury Adjustments
+
+Using 675k ADA in Treasury and ~100k in sOADA as OADA fees, acquire wanUSDC for the purposes of further management of our launch of OUSD in the coming months.
+
+Execution of the swap at best possible rate given a reasonable window of ~7 days after the proposal is accepted is given to Optim Labs.


### PR DESCRIPTION
# 0023-OUSDPrep

- Status: Proposed
- Authors: Optim Labs

## Treasury Allocation

In order to prepare ourselves for the OUSD launch, we must seed the liqudity for it. A brave move in interim to have the $O token be the primary source of wanUSDC liquidity on Cardano is proposed.

## Liquidity Adjustments

Withdraw 1M out of 1.1M (OADA + ADA) liquidity from the OADA/ADA stableswap. Swap all ADA into wanUSDC, and keep the OADA for the OADA/OUSD pool. 
Withdraw the liquidity from the O/ADA pool on Splash and use the ADA to acquire wanUSDC. Provide the liquidity back.
Withdraw the liquidity from the O/OADA pool on Splash and convert 500k OADA into wanUSDC. Provide it as liquitiy back.
Withdraw the liquidity from the OADA/ADA pool on Wingriders and convert all of it into wanUSDC. Sideline it into the ODAO Treasury.

Liquidity mangement, fees and dex allocation remain under control of ODAO Council.

Execution of the swap at best possible rate given a reasonable window of ~7 days after the proposal is accepted is given to Optim Labs.

The intention is to, after the launch of OUSD, is to use the wanUSDC stable as a reserve asset and convert this liquidity into OUSD.

## Treasury Adjustments

Using 675k ADA in Treasury and ~100k in sOADA as OADA fees, acquire wanUSDC for the purposes of further management of our launch of OUSD in the coming months.

Execution of the swap at best possible rate given a reasonable window of ~7 days after the proposal is accepted is given to Optim Labs.