### PR TITLE
0024-SPLASHDivestment

### DIFF
--- a/0024-SPLASHDivestment.md
+++ b/0024-SPLASHDivestment.md
@@ -1,0 +1,45 @@
+# 0024-SPLASHDivestment
+
+- Status: Proposed
+- Authors: Optim Labs
+
+## Context
+
+Given recent development and strategic considerations the ODAO Council and Optim Labs propose divestment of SPLASH approved in prior proposals. The teams will continue working together for the forseeable future on upcoming products, but necessity given the fallout of the situation surrounding the villification of Optim by the Cardano insiders make it necessary to rethink the long banded approach to our products and company.
+
+## Proposal
+
+### Swap
+
+#### Swap Context 
+
+OTC swap ODAO owned SPLASH for $O and ADA with Splash DAO  
+
+The ODAO will swap:
+4,120,357.651005 SPLASH  
+spot price: 0.106846  
+value in ADA: 440,243.733579  
+
+For:
+308,098.590000 O  
+spot price: 0.279377  
+value in ADA: 86,075.659778  
+
+and  
+
+440,243.733579 - 86,075.659778  
+=  
+354,168.07 ADA  
+
+#### Swap Final
+
+Thus, a swap of
+4,120,357.651005 SPLASH  
+
+for 
+354,168.07 ADA  
+308,098.590000 O  
+
+### Vote
+
+In the upcoming Splash DAO vote, vote up a proposal that matches these terms as above using all of the ODAO holdings.


### PR DESCRIPTION
# 0024-SPLASHDivestment

- Status: Proposed
- Authors: Optim Labs

## Context

Given recent development and strategic considerations the ODAO Council and Optim Labs propose divestment of SPLASH approved in prior proposals. The teams will continue working together for the forseeable future on upcoming products, but necessity given the fallout of the situation surrounding the villification of Optim by the Cardano insiders make it necessary to rethink the long banded approach to our products and company.

## Proposal

### Swap

#### Swap Context 

OTC swap ODAO owned SPLASH for $O and ADA with Splash DAO  

The ODAO will swap:
4,120,357.651005 SPLASH  
spot price: 0.106846  
value in ADA: 440,243.733579  

For:
308,098.590000 O  
spot price: 0.279377  
value in ADA: 86,075.659778  

and  

440,243.733579 - 86,075.659778  
=  
354,168.07 ADA  

#### Swap Final

Thus, a swap of
4,120,357.651005 SPLASH  

for 
354,168.07 ADA  
308,098.590000 O  

### Vote

In the upcoming Splash DAO vote, vote up a proposal that matches these terms as above using all of the ODAO holdings.