### PR TITLE
Proposal 0028 -- OADA V2

### DIFF
--- a/0028-OADAV2/0028-OADAV2.md
+++ b/0028-OADAV2/0028-OADAV2.md
@@ -26,7 +26,7 @@ Max Duration: 1 Month
 Min Duration: 1 Month
 
 ### sOADA Capacity Reduction
-We push down the max limit of sOADA to 5M. We give authority to the ODAO Council to increase capacity maximally (but without need to) 2M sOADA per month, starting in February.
+We push down the max limit of sOADA to 2M. We give authority to the ODAO Council to increase capacity maximally (but without need to) 2M sOADA per month, starting in February.
 
 ### Liquidity Operations
 For the purposes of providing a credit line from ODAO to any distressed loans we provide capacity for ODAO Council to lend out from ODAO Treasury upwards of 700k OADA on same terms as the OADA System does, explicitly to refinance loans in case the OADA System hits capacity.

--- a/0028-OADAV2/0028-OADAV2.md
+++ b/0028-OADAV2/0028-OADAV2.md
@@ -1,0 +1,37 @@
+# 0028 - OADA V2
+
+- Status: Proposed
+- Authors: Optim Labs
+
+## Context
+
+This proposal greenlights the launch of OADA V2, with a proposed update time of 2025.11.25, in the european evening.
+
+We add SNEK as the first and only collateral asset to it as the most active and traded asset on Cardano, to benchmark performance and market fit for future additions.
+
+Furthermore, we perform treasury operations to accelerate the growth of this much improved system.
+
+## Proposal
+
+### OADA V1 -> V2 Update
+We define "OADA V2", "The OADA System" as a system deployment with equivalent parameter set and behavior to that outlined in [This Document](https://github.com/OptimFinance/public-documents/blob/main/The%20OADA%20System%20V2.pdf) to be the next version of OADA, upgraded via the Soul Token authority given to ODAO Core from the existing OADA deployment.
+
+### OADA V2: SNEK Collateral Market Configuration
+Asset: asset108xu02ckwrfc8qs9d97mgyh4kn8gdu9w8f5sxk (SNEK)
+Liquidation LTV: 150%
+Origination LTV: 170%
+Oracle Price Feed: [Charlie3 SNEK/ADA](https://portal.charli3.io/dev/feeds/snek-ada?network=Mainnet)
+Maximum Capacity: 2M OADA (Utilized as: 500k Target, 1M Auto-Expand, 500k Reserve)
+Max Duration: 1 Month
+Min Duration: 1 Month
+
+### sOADA Capacity Reduction
+We push down the max limit of sOADA to 5M. We give authority to the ODAO Council to increase capacity maximally (but without need to) 2M sOADA per month, starting in February.
+
+### Liquidity Operations
+For the purposes of providing a credit line from ODAO to any distressed loans we provide capacity for ODAO Council to lend out from ODAO Treasury upwards of 700k OADA on same terms as the OADA System does, explicitly to refinance loans in case the OADA System hits capacity.
+
+To that end, we additionally withdraw the liquidity from the O/OADA pool (~179k OADA) in order to facilitate further security of the credit line backup.
+
+### Capital Optimization
+We mobilize inactive holdings of ~371k ADA to be put into sOADA.

--- a/0028-OADAV2/0028-OADAV2.md
+++ b/0028-OADAV2/0028-OADAV2.md
@@ -21,7 +21,7 @@ Asset: asset108xu02ckwrfc8qs9d97mgyh4kn8gdu9w8f5sxk (SNEK)
 Liquidation LTV: 150%
 Origination LTV: 170%
 Oracle Price Feed: [Charlie3 SNEK/ADA](https://portal.charli3.io/dev/feeds/snek-ada?network=Mainnet)
-Maximum Capacity: 2M OADA (Utilized as: 500k Target, 1M Auto-Expand, 500k Reserve)
+Maximum Capacity: 1M OADA (Utilized as: 250k Target, 500k Auto-Expand, 250k Reserve)
 Max Duration: 1 Month
 Min Duration: 1 Month
 


### PR DESCRIPTION
This proposal greenlights the launch of OADA V2, with a proposed update time of 2025.11.25, in the european evening.

We add SNEK as the first and only collateral asset to it as the most active and traded asset on Cardano, to benchmark performance and market fit for future additions.

Furthermore, we perform treasury operations to accelerate the growth of this much improved system.

[RENDERED](https://github.com/OptimFinance/odao-proposals/blob/proposal0028/0028-OADAV2/0028-OADAV2.md)